### PR TITLE
Add draggable resizable slicing frame

### DIFF
--- a/Moji Slicer/ContentView.swift
+++ b/Moji Slicer/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @State private var horizontalGap = 0.0
     @State private var verticalGap = 0.0
     @State private var padding = 0.0
+    @State private var cropRect: CGRect?
     @State private var showingImporter = false
     @State private var message: String?
     @State private var isErrorMessage = false
@@ -18,12 +19,17 @@ struct ContentView: View {
     private var safeVerticalGap: Double { max(verticalGap, 0) }
     private var safePadding: Double { max(padding, 0) }
 
+    private var activeCropRect: CGRect? {
+        guard let image else { return nil }
+        return normalizedCropRect(for: image)
+    }
+
     private var frames: [GridFramePlan] {
-        guard let image else { return [] }
+        guard let bounds = activeCropRect else { return [] }
         let spec = GridSpec(
             rows: rows,
             columns: columns,
-            bounds: CGRect(origin: .zero, size: image.size),
+            bounds: bounds,
             horizontalGap: safeHorizontalGap,
             verticalGap: safeVerticalGap,
             padding: safePadding
@@ -92,6 +98,18 @@ struct ContentView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
+                Text("Slice Frame")
+                    .font(.headline)
+                Text("Drag the frame or its corner handles in the preview.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Reset Frame") {
+                    resetCropRect()
+                }
+                .disabled(image == nil)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
                 Text("Output")
                     .font(.headline)
                 Text("\(frames.count) frames")
@@ -117,9 +135,16 @@ struct ContentView: View {
     private var preview: some View {
         ZStack {
             Color(nsColor: .windowBackgroundColor)
-            if let image {
-                GridPreview(image: image, frames: frames)
-                    .padding(32)
+            if let image, let cropRect = activeCropRect {
+                GridPreview(
+                    image: image,
+                    cropRect: cropRect,
+                    frames: frames,
+                    onCropRectChanged: { newRect in
+                        self.cropRect = newRect
+                    }
+                )
+                .padding(32)
             } else {
                 ContentUnavailableView(
                     "Import a grid image",
@@ -153,6 +178,7 @@ struct ContentView: View {
             }
             image = loadedImage
             imageName = url.lastPathComponent
+            cropRect = CGRect(origin: .zero, size: loadedImage.size)
             showMessage("Loaded \(url.lastPathComponent).", isError: false)
         } catch {
             showMessage(error.localizedDescription, isError: true)
@@ -191,6 +217,21 @@ struct ContentView: View {
         }
     }
 
+    private func resetCropRect() {
+        guard let image else { return }
+        cropRect = CGRect(origin: .zero, size: image.size)
+    }
+
+    private func normalizedCropRect(for image: NSImage) -> CGRect {
+        let imageBounds = CGRect(origin: .zero, size: image.size)
+        guard var rect = cropRect else { return imageBounds }
+        rect = rect.standardized.intersection(imageBounds)
+        if rect.width < 1 || rect.height < 1 {
+            return imageBounds
+        }
+        return rect
+    }
+
     private func showMessage(_ text: String, isError: Bool) {
         message = text
         isErrorMessage = isError
@@ -199,32 +240,172 @@ struct ContentView: View {
 
 private struct GridPreview: View {
     let image: NSImage
+    let cropRect: CGRect
     let frames: [GridFramePlan]
+    let onCropRectChanged: (CGRect) -> Void
 
     var body: some View {
         GeometryReader { geometry in
-            let scale = min(
-                geometry.size.width / max(image.size.width, 1),
-                geometry.size.height / max(image.size.height, 1)
-            )
-            let displaySize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
-            let origin = CGPoint(x: (geometry.size.width - displaySize.width) / 2, y: (geometry.size.height - displaySize.height) / 2)
+            let metrics = PreviewMetrics(imageSize: image.size, availableSize: geometry.size)
 
             ZStack(alignment: .topLeading) {
                 Image(nsImage: image)
                     .resizable()
                     .interpolation(.none)
-                    .frame(width: displaySize.width, height: displaySize.height)
+                    .frame(width: metrics.displaySize.width, height: metrics.displaySize.height)
                     .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
 
                 ForEach(frames) { frame in
+                    let displayRect = metrics.displayRect(for: frame.rect)
                     Rectangle()
                         .stroke(.blue, lineWidth: 1)
-                        .frame(width: frame.rect.width * scale, height: frame.rect.height * scale)
-                        .position(x: origin.x + frame.rect.midX * scale, y: origin.y + frame.rect.midY * scale)
+                        .frame(width: displayRect.width, height: displayRect.height)
+                        .position(x: displayRect.midX, y: displayRect.midY)
                 }
+
+                ResizableCropOverlay(
+                    cropRect: cropRect,
+                    metrics: metrics,
+                    onCropRectChanged: onCropRectChanged
+                )
             }
         }
+    }
+}
+
+private struct ResizableCropOverlay: View {
+    let cropRect: CGRect
+    let metrics: PreviewMetrics
+    let onCropRectChanged: (CGRect) -> Void
+
+    private let minimumSize: CGFloat = 12
+    private let handleSize: CGFloat = 12
+
+    var body: some View {
+        let displayRect = metrics.displayRect(for: cropRect)
+
+        ZStack(alignment: .topLeading) {
+            Rectangle()
+                .stroke(.orange, style: StrokeStyle(lineWidth: 2, dash: [7, 4]))
+                .background(Color.orange.opacity(0.08))
+                .frame(width: displayRect.width, height: displayRect.height)
+                .position(x: displayRect.midX, y: displayRect.midY)
+                .contentShape(Rectangle())
+                .gesture(moveGesture())
+
+            ForEach(CropHandle.allCases, id: \.self) { handle in
+                Rectangle()
+                    .fill(Color.orange)
+                    .frame(width: handleSize, height: handleSize)
+                    .position(handle.position(in: displayRect))
+                    .gesture(resizeGesture(for: handle))
+            }
+        }
+    }
+
+    private func moveGesture() -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                let delta = CGSize(
+                    width: value.translation.width / metrics.scale,
+                    height: value.translation.height / metrics.scale
+                )
+                updateCropRect(cropRect.offsetBy(dx: delta.width, dy: delta.height))
+            }
+    }
+
+    private func resizeGesture(for handle: CropHandle) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                let dx = value.translation.width / metrics.scale
+                let dy = value.translation.height / metrics.scale
+                var rect = cropRect
+
+                switch handle {
+                case .topLeft:
+                    rect.origin.x += dx
+                    rect.origin.y += dy
+                    rect.size.width -= dx
+                    rect.size.height -= dy
+                case .topRight:
+                    rect.origin.y += dy
+                    rect.size.width += dx
+                    rect.size.height -= dy
+                case .bottomLeft:
+                    rect.origin.x += dx
+                    rect.size.width -= dx
+                    rect.size.height += dy
+                case .bottomRight:
+                    rect.size.width += dx
+                    rect.size.height += dy
+                }
+
+                updateCropRect(rect)
+            }
+    }
+
+    private func updateCropRect(_ rect: CGRect) {
+        let imageBounds = CGRect(origin: .zero, size: metrics.imageSize)
+        let normalized = rect.standardized
+        let clamped = CGRect(
+            x: min(max(normalized.minX, imageBounds.minX), imageBounds.maxX - minimumSize),
+            y: min(max(normalized.minY, imageBounds.minY), imageBounds.maxY - minimumSize),
+            width: min(max(normalized.width, minimumSize), imageBounds.maxX - min(max(normalized.minX, imageBounds.minX), imageBounds.maxX - minimumSize)),
+            height: min(max(normalized.height, minimumSize), imageBounds.maxY - min(max(normalized.minY, imageBounds.minY), imageBounds.maxY - minimumSize))
+        )
+        onCropRectChanged(clamped)
+    }
+}
+
+private enum CropHandle: CaseIterable {
+    case topLeft
+    case topRight
+    case bottomLeft
+    case bottomRight
+
+    func position(in rect: CGRect) -> CGPoint {
+        switch self {
+        case .topLeft:
+            return CGPoint(x: rect.minX, y: rect.minY)
+        case .topRight:
+            return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottomLeft:
+            return CGPoint(x: rect.minX, y: rect.maxY)
+        case .bottomRight:
+            return CGPoint(x: rect.maxX, y: rect.maxY)
+        }
+    }
+}
+
+private struct PreviewMetrics {
+    let imageSize: CGSize
+    let availableSize: CGSize
+
+    var scale: CGFloat {
+        min(
+            availableSize.width / max(imageSize.width, 1),
+            availableSize.height / max(imageSize.height, 1)
+        )
+    }
+
+    var displaySize: CGSize {
+        CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
+    }
+
+    var origin: CGPoint {
+        CGPoint(
+            x: (availableSize.width - displaySize.width) / 2,
+            y: (availableSize.height - displaySize.height) / 2
+        )
+    }
+
+    func displayRect(for imageRect: CGRect) -> CGRect {
+        CGRect(
+            x: origin.x + imageRect.minX * scale,
+            y: origin.y + imageRect.minY * scale,
+            width: imageRect.width * scale,
+            height: imageRect.height * scale
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a draggable, resizable slicing frame to the v2 preview canvas.

## Changes

- Adds crop-frame state to `ContentView`.
- Initializes the frame to the full imported image.
- Adds an orange draggable crop overlay on the preview canvas.
- Adds four corner handles for resizing the slicing frame with the mouse.
- Calculates grid frames inside the active crop frame instead of always using the full image.
- Adds a Reset Frame button.
- Keeps PNG export using the same grid frame list shown in preview.

## Notes

This is the first interaction pass. It intentionally starts with whole-frame drag plus corner resizing only; edge handles and more polished cursor feedback can be added after the core behavior is validated.
